### PR TITLE
Add interactive directory prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,12 @@ kickbike_analysis/
 ## データセット準備
 
 各動画からフレーム単位の特徴量をあらかじめ抽出して ``.npy`` ファイルに保存する
-スクリプト `prepare_dataset.py` を用意しています。動画ファイルは
-`D:\20250525_ビタミンiファクトリーイベント動画` に置かれている想定です。
+スクリプト `prepare_dataset.py` を用意しています。動画フォルダは起動後に入力することもできます。
+入力を省略した場合は `data/` フォルダが使用されます。
 
 ```bash
+python -m kickbike_analysis.prepare_dataset
+# もしくはパスを直接指定
 python -m kickbike_analysis.prepare_dataset "D:\\20250525_ビタミンiファクトリーイベント動画"
 ```
 
@@ -66,15 +68,16 @@ python -m kickbike_analysis.analyze_video "D:\\20250525_ビタミンiファク�
 
 ## 学習の実行
 
-学習用の動画と `labels.csv` をまとめたディレクトリを用意し、依存パッケージをインストールした上で `train.py` を実行します。データディレクトリを省略すると `data/` が使用されます。ディレクトリには `*.mp4` 形式の動画と対応するラベルを記述した `labels.csv` を置いてください。動画が存在しない、または動きが検出できない場合はエラーとなります。
+学習用の動画と `labels.csv` をまとめたディレクトリを用意し、依存パッケージをインストールした上で `train.py` を実行します。ディレクトリは実行後に入力することも可能で、入力を省略すると `data/` が使用されます。ディレクトリには `*.mp4` 形式の動画と対応するラベルを記述した `labels.csv` を置いてください。動画が存在しない、または動きが検出できない場合はエラーとなります。
 
 
 ```bash
 # 依存ライブラリのインストール (リポジトリ直下に `requirements.txt` を同梱しています)
 pip install -r requirements.txt
 
-
-# 例: Windows 上の動画ディレクトリを指定して学習
+# フォルダ入力を促すモードで学習開始
+python -m kickbike_analysis.train
+# 直接パスを指定することも可能
 python -m kickbike_analysis.train "D:\\20250525_ビタミンiファクトリーイベント動画"
 
 ```

--- a/kickbike_analysis/prepare_dataset.py
+++ b/kickbike_analysis/prepare_dataset.py
@@ -18,5 +18,11 @@ def prepare(dataset_dir: Path):
 
 if __name__ == "__main__":
     import sys
-    path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("data")
+    if len(sys.argv) > 1:
+        path = Path(sys.argv[1])
+    else:
+        user_input = input(
+            "動画が保存されているフォルダを指定してください (空欄で 'data' フォルダを使用します): "
+        ).strip()
+        path = Path(user_input) if user_input else Path("data")
     prepare(path)

--- a/kickbike_analysis/train.py
+++ b/kickbike_analysis/train.py
@@ -84,6 +84,13 @@ def train(dataset_dir: Path, epochs: int = 10):
 
 if __name__ == "__main__":
     import sys
-    dataset_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("data")
+    if len(sys.argv) > 1:
+        dataset_path = Path(sys.argv[1])
+    else:
+        prompt = (
+            "学習用動画フォルダのパスを入力してください (空欄で 'data' フォルダを使用します): "
+        )
+        inp = input(prompt).strip()
+        dataset_path = Path(inp) if inp else Path("data")
     trained_model = train(dataset_path)
     torch.save(trained_model.state_dict(), "model.pt")


### PR DESCRIPTION
## Summary
- prompt for folder path when running `prepare_dataset.py` or `train.py` without arguments
- mention interactive use in README for dataset prep and training

## Testing
- `python -m py_compile kickbike_analysis/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6858af78a4608332993088f9a24b0bfa