### PR TITLE
Enable direct execution of analysis scripts

### DIFF
--- a/kickbike_analysis/analyze_video.py
+++ b/kickbike_analysis/analyze_video.py
@@ -3,8 +3,13 @@ from typing import List, Tuple
 import numpy as np
 import cv2
 
-from .data_loader import load_video_frames
-from .feature_extractor import compute_frame_features
+# Allow running as a standalone script without package context
+try:  # pragma: no cover - simple import fallback
+    from .data_loader import load_video_frames
+    from .feature_extractor import compute_frame_features
+except ImportError:  # run as script
+    from data_loader import load_video_frames
+    from feature_extractor import compute_frame_features
 
 
 
@@ -52,8 +57,9 @@ def analyze(video_path: Path) -> List[Tuple[str, str, str]]:
 
 if __name__ == "__main__":
     import sys
+
     if len(sys.argv) < 2:
-        print("Usage: python -m kickbike_analysis.analyze_video <video_path>")
+        print("Usage: python kickbike_analysis/analyze_video.py <video_path>")
         sys.exit(1)
     path = Path(sys.argv[1])
 

--- a/kickbike_analysis/cluster.py
+++ b/kickbike_analysis/cluster.py
@@ -6,8 +6,13 @@ import joblib
 import numpy as np
 from sklearn.cluster import KMeans
 
-from .data_loader import load_video_frames
-from .feature_extractor import compute_frame_features
+# Allow importing when executed as standalone scripts
+try:  # pragma: no cover - import fallback
+    from .data_loader import load_video_frames
+    from .feature_extractor import compute_frame_features
+except ImportError:  # run as script
+    from data_loader import load_video_frames
+    from feature_extractor import compute_frame_features
 
 
 def _video_features(video: Path) -> List[np.ndarray]:

--- a/kickbike_analysis/infer.py
+++ b/kickbike_analysis/infer.py
@@ -1,8 +1,13 @@
 """Inference using a fitted clustering model."""
 from pathlib import Path
 
-from .cluster import load_model, predict_cluster
-from .analyze_video import analyze
+# Support running as a standalone script
+try:  # pragma: no cover - import fallback
+    from .cluster import load_model, predict_cluster
+    from .analyze_video import analyze
+except ImportError:  # run as script
+    from cluster import load_model, predict_cluster
+    from analyze_video import analyze
 
 
 

--- a/kickbike_analysis/live_demo.py
+++ b/kickbike_analysis/live_demo.py
@@ -18,14 +18,25 @@ import torch
 from ultralytics import YOLO
 from ultralytics.trackers.byte_tracker import BYTETracker
 
-from .feature_extractor import (
-    _bike_tilt,
-    _face_direction,
-    _foot_amplitude,
-    _kick_period,
-    _posture_stability,
-    _iou,
-)
+# Allow execution both as a module and as a standalone script
+try:  # pragma: no cover - import fallback
+    from .feature_extractor import (
+        _bike_tilt,
+        _face_direction,
+        _foot_amplitude,
+        _kick_period,
+        _posture_stability,
+        _iou,
+    )
+except ImportError:  # run as script
+    from feature_extractor import (
+        _bike_tilt,
+        _face_direction,
+        _foot_amplitude,
+        _kick_period,
+        _posture_stability,
+        _iou,
+    )
 
 # COCO style skeleton pairs used by YOLOv8 pose model
 _SKELETON = [
@@ -159,6 +170,6 @@ if __name__ == "__main__":
     import sys
 
     if len(sys.argv) < 2:
-        print("Usage: python -m kickbike_analysis.live_demo <video_path>")
+        print("Usage: python kickbike_analysis/live_demo.py <video_path>")
         raise SystemExit(1)
     show(Path(sys.argv[1]))

--- a/kickbike_analysis/prepare_dataset.py
+++ b/kickbike_analysis/prepare_dataset.py
@@ -1,8 +1,13 @@
 from pathlib import Path
 import numpy as np
 
-from .data_loader import load_video_frames
-from .feature_extractor import compute_frame_features
+# Allow this file to run as a standalone script
+try:  # pragma: no cover - fallback for script execution
+    from .data_loader import load_video_frames
+    from .feature_extractor import compute_frame_features
+except ImportError:  # run as script
+    from data_loader import load_video_frames
+    from feature_extractor import compute_frame_features
 
 
 def prepare(dataset_dir: Path):

--- a/kickbike_analysis/train.py
+++ b/kickbike_analysis/train.py
@@ -2,7 +2,11 @@
 from pathlib import Path
 import sys
 
-from .cluster import save_model, train_clusters
+# Support running as a standalone script
+try:  # pragma: no cover - import fallback
+    from .cluster import save_model, train_clusters
+except ImportError:  # run as script
+    from cluster import save_model, train_clusters
 
 
 def main(dataset_path: Path, out_path: Path = Path("clusters.pkl")) -> None:


### PR DESCRIPTION
## Summary
- allow scripts to be run directly by falling back to absolute imports when package context is missing
- adjust CLI usage messages to reflect standalone execution

## Testing
- `python kickbike_analysis/analyze_video.py` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688c2e395ff08332ab7c7ac0fc678b31