### PR TITLE
Add training and model-based inference scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,38 +23,49 @@ kickbike_analysis/
 ├── quality_checker.py # 画質・構図の簡易チェック
 ├── scoring.py         # 特徴量からスコアとアドバイスを算出
 ├── segmentation.py    # 走行シーンの簡易セグメント化 (将来拡張用)
-├── infer.py           # 推論ユーティリティ
-├── train.py           # 学習スクリプト（骨組みのみ）
-└── prepare_dataset.py # 特徴量前計算スクリプト
+├── infer.py           # 学習済みモデルを用いた推論
+├── train.py           # ロジスティック回帰による学習スクリプト
+├── prepare_dataset.py # 特徴量前計算スクリプト
+└── extract_images.py  # 学習用の切り出し画像作成
 ```
 
 ## 使い方
 
-### 推論を試す
+### 0. 学習用画像を切り出す（任意）
+
+教師データを準備するため、動画から人物+バイクの領域を切り出して画像として保存できます。
 
 ```bash
-python -m kickbike_analysis.analyze_video <video_path>
+python -m kickbike_analysis.extract_images <video_dir> <out_dir> --limit 1000
 ```
 
-各人物について `score`, `category`, `advices`, `quality` を含む結果と
-判定付き画像が出力されます。簡易ラッパとして `infer.py` も利用できます。
+`<out_dir>` には最大 `--limit` 枚の画像が保存されます。
 
-```bash
-python -m kickbike_analysis.infer <video_path>
-```
+### 1. 画像認識（特徴量抽出）
 
-### データセット準備
-
-`prepare_dataset.py` で特徴量を前計算して ``.npy`` ファイルに保存できます。
+`prepare_dataset.py` で動画から人物ごとの特徴量を計算し ``CSV`` や ``npy`` に保存できます。
 
 ```bash
 python -m kickbike_analysis.prepare_dataset <video_dir>
 ```
 
-### 学習（未実装）
+### 2. 学習
 
-`train.py` は将来の分類器/強化学習モデル学習用の骨組みのみです。
-データセット形式が固まり次第、実装を追加する予定です。
+`train.py` に特徴量とラベルを格納した ``CSV`` を渡すとロジスティック回帰モデルを学習し ``model.pkl`` を出力します。
+
+```bash
+python -m kickbike_analysis.train <dataset.csv> [out_model.pkl]
+```
+
+### 3. 推論を試す
+
+学習済みモデルと解析したい動画を指定して推論を実行します。
+
+```bash
+python -m kickbike_analysis.infer <video_path> <model.pkl>
+```
+
+各人物について `score`, `category`, `advices`, `quality` を含む結果と判定付き画像が出力されます。
 
 ## 依存ライブラリ
 

--- a/kickbike_analysis/extract_images.py
+++ b/kickbike_analysis/extract_images.py
@@ -1,0 +1,66 @@
+"""動画から学習用の切り出し画像を保存する補助スクリプト。
+
+指定したフォルダ内の ``.mp4`` 動画を順に処理し、
+人物+バイク領域を切り出した画像を最大 ``limit`` 枚まで保存する。
+将来の教師データ作成やアノテーション作業を想定している。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import cv2
+
+try:  # pragma: no cover - スクリプト実行時のフォールバック
+    from .data_loader import load_video_frames
+    from .feature_extractor import compute_frame_features
+except ImportError:  # run as standalone script
+    from data_loader import load_video_frames
+    from feature_extractor import compute_frame_features
+
+
+def extract_images(video_dir: Path, out_dir: Path, limit: int = 1000) -> None:
+    """動画から人物の切り出し画像を保存する。
+
+    Parameters
+    ----------
+    video_dir: Path
+        ``.mp4`` 動画が格納されたディレクトリ。
+    out_dir: Path
+        画像の保存先ディレクトリ。
+    limit: int, default 1000
+        保存する最大枚数。
+    """
+
+    video_dir = Path(video_dir)
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    saved = 0
+    for video in video_dir.glob("*.mp4"):
+        frames = load_video_frames(video)
+        _, crops = compute_frame_features(frames, return_crops=True)
+        for frame_img, bbox in crops:
+            x1, y1, x2, y2 = bbox
+            img = frame_img[y1:y2, x1:x2]
+            out_file = out_dir / f"{video.stem}_{saved:04d}.jpg"
+            cv2.imwrite(str(out_file), img)
+            saved += 1
+            if saved >= limit:
+                print(f"{saved} 枚の画像を保存しました: {out_dir}")
+                return
+    print(f"{saved} 枚の画像を保存しました: {out_dir}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    import argparse
+
+    parser = argparse.ArgumentParser(description="学習用の切り出し画像を作成する")
+    parser.add_argument("video_dir", type=Path, help="動画があるディレクトリ")
+    parser.add_argument("out_dir", type=Path, help="切り出し画像の保存先")
+    parser.add_argument(
+        "--limit", type=int, default=1000, help="保存する最大枚数 (デフォルト1000)"
+    )
+    args = parser.parse_args()
+    extract_images(args.video_dir, args.out_dir, args.limit)

--- a/kickbike_analysis/infer.py
+++ b/kickbike_analysis/infer.py
@@ -1,35 +1,101 @@
-"""推論用ユーティリティ。
-
-学習済みモデルを必要とせず、`analyze_video` の結果をそのまま
-返す簡易版である。将来的には学習済み分類器や強化学習モデルを
-読み込んで使用する予定。
-"""
+"""学習済みモデルを用いた推論ユーティリティ。"""
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Dict
+from typing import Dict, List
+
+import cv2
+import joblib
 
 # パッケージ外からも実行できるようにする
 try:  # pragma: no cover - import fallback
-    from .analyze_video import analyze
+    from .data_loader import load_video_frames
+    from .feature_extractor import compute_frame_features
+    from .quality_checker import check_quality
+    from .scoring import score_features
 except ImportError:  # run as script
-    from analyze_video import analyze
+    from data_loader import load_video_frames
+    from feature_extractor import compute_frame_features
+    from quality_checker import check_quality
+    from scoring import score_features
 
 
-def predict(video_path: Path) -> List[Dict[str, object]]:
-    """動画から人物ごとのスコアと判定を取得する。"""
-    return analyze(video_path)
+def predict(video_path: Path, model_path: Path) -> List[Dict[str, object]]:
+    """動画から特徴量を抽出し学習済みモデルでカテゴリを推定する。"""
+
+    frames = list(load_video_frames(video_path))
+    if not frames:
+        return [
+            {
+                "score": 0,
+                "category": "不明",
+                "advices": ["動画を読み込めませんでした"],
+                "image_path": "",
+                "quality": [],
+            }
+        ]
+
+    features, crops = compute_frame_features(frames, return_crops=True)
+    if features.size == 0:
+        return [
+            {
+                "score": 0,
+                "category": "不明",
+                "advices": ["動きが検出できませんでした"],
+                "image_path": "",
+                "quality": [],
+            }
+        ]
+
+    model = joblib.load(model_path)
+
+    results: List[Dict[str, object]] = []
+    for idx, (vec, crop) in enumerate(zip(features, crops), start=1):
+        pred = model.predict([vec])[0]
+        prob = model.predict_proba([vec])[0]
+        label_index = list(model.classes_).index(pred)
+        score = int(prob[label_index] * 100)
+        _, _, advices = score_features(vec)
+
+        frame_img, bbox = crop
+        x1, y1, x2, y2 = bbox
+        img = frame_img[y1:y2, x1:x2].copy()
+        cv2.putText(
+            img,
+            f"{score} {pred}",
+            (5, 20),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.6,
+            (0, 255, 0) if pred == "Ready" else (0, 0, 255),
+            2,
+        )
+        out_file = video_path.with_name(f"{video_path.stem}_person{idx}.jpg")
+        cv2.imwrite(str(out_file), img)
+
+        quality = check_quality(frame_img, bbox)
+
+        results.append(
+            {
+                "score": score,
+                "category": str(pred),
+                "advices": advices,
+                "image_path": str(out_file),
+                "quality": quality,
+            }
+        )
+
+    return results
 
 
 if __name__ == "__main__":  # pragma: no cover
     import sys
 
-    if len(sys.argv) < 2:
-        print("Usage: python -m kickbike_analysis.infer <video_path>")
+    if len(sys.argv) < 3:
+        print("Usage: python -m kickbike_analysis.infer <video_path> <model.pkl>")
         sys.exit(1)
 
-    res = predict(Path(sys.argv[1]))
+    res = predict(Path(sys.argv[1]), Path(sys.argv[2]))
     for r in res:
         print(f"{r['score']}点 {r['category']} -> {r['image_path']}")
         if r["advices"]:

--- a/kickbike_analysis/train.py
+++ b/kickbike_analysis/train.py
@@ -1,34 +1,71 @@
 """乗りこなし判定モデルの学習エントリーポイント。
 
-現在は骨組みのみで、特徴量とラベルから分類器や強化学習モデルを
-学習する実装は未着手である。今後、要件定義8章で述べられている
-オフラインRLや模倣学習を取り入れた学習手順を実装する予定。
+簡易的な実装として、特徴量とラベルが保存された ``CSV`` ファイルを
+読み込みロジスティック回帰分類器を学習し ``joblib`` 形式で保存する。
+将来的には要件定義8章で述べられているようなオフラインRLや模倣学習を
+取り入れた学習手順へ置き換える予定である。
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
+import joblib
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+
+def _resolve_dataset(path: Path) -> Path:
+    """引数がディレクトリの場合は ``data.csv`` を探し、
+    ファイルの場合はそのまま返す。"""
+
+    path = Path(path)
+    if path.is_dir():
+        csv_file = path / "data.csv"
+        if not csv_file.exists():
+            raise FileNotFoundError(f"データセット {csv_file} が見つかりません")
+        return csv_file
+    if not path.exists():
+        raise FileNotFoundError(f"データセット {path} が見つかりません")
+    return path
+
 
 def main(dataset_path: Path, out_path: Path = Path("model.pkl")) -> None:
-    """指定ディレクトリから学習データを読み込みモデルを保存する。
+    """CSV 形式の特徴量とラベルからモデルを学習し保存する。
 
     Parameters
     ----------
     dataset_path: Path
-        特徴量とラベルを含むディレクトリ。
+        ``f1``〜``f6`` と ``label`` 列を含む ``CSV`` ファイル、
+        もしくはそれを格納したディレクトリ。
     out_path: Path
         学習済みモデルの出力先。
     """
-    raise NotImplementedError(
-        "学習処理は未実装です。データセットの形式が固まり次第追加予定です。"
-    )
+
+    csv_file = _resolve_dataset(dataset_path)
+
+    df = pd.read_csv(csv_file)
+    X = df.drop(columns=[df.columns[-1]]).values
+    y = df[df.columns[-1]].values
+
+    pipe = Pipeline([
+        ("scaler", StandardScaler()),
+        ("clf", LogisticRegression(max_iter=1000)),
+    ])
+    pipe.fit(X, y)
+
+    joblib.dump(pipe, out_path)
+    print(f"モデルを保存しました: {out_path}")
 
 
 if __name__ == "__main__":
     import sys
 
     if len(sys.argv) < 2:
-        print("Usage: python -m kickbike_analysis.train <dataset_dir>")
-    else:
+        print("Usage: python -m kickbike_analysis.train <dataset.csv> [out_model.pkl]")
+    elif len(sys.argv) == 2:
         main(Path(sys.argv[1]))
+    else:
+        main(Path(sys.argv[1]), Path(sys.argv[2]))


### PR DESCRIPTION
## Summary
- implement logistic regression training that saves models as joblib
- add model-based inference with feature extraction and quality check
- document full recognize-train-infer workflow in README
- add helper to extract up to 1000 training images from videos and document its usage

## Testing
- `python -m kickbike_analysis.extract_images dummy_videos out_images --limit 10` *(fails: ImportError: libGL.so.1)*
- `python -m kickbike_analysis.train sample_dataset.csv model.pkl`


------
https://chatgpt.com/codex/tasks/task_e_68c591fe06c08332ab2cae2780bef4f3